### PR TITLE
Runtime optimization

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::hash::{Hash, Hasher};
 
 #[derive(Deserialize, Debug)]
 pub struct Biomarker {
@@ -34,4 +35,18 @@ pub struct Specimen {
 pub struct BiomarkerScore {
     pub biomarker_id: String,
     pub biomarker_score: f64,
+}
+
+impl PartialEq for BiomarkerScore {
+    fn eq(&self, other: &Self) -> bool {
+        self.biomarker_id == other.biomarker_id
+    }
+}
+
+impl Eq for BiomarkerScore {}
+
+impl Hash for BiomarkerScore {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.biomarker_id.hash(state);
+    }
 }


### PR DESCRIPTION
Optimized runtime complexity. 
- Removed need for `biomarker_id` clone by implementing `Hash`, `Eq`, and `PartialEq` traits on `BiomarkerScore` struct so the scores can be stored directly in a `HashSet` instead of a `HashMap`. 
- Chained top level and component `evidence_source` iterators to reduce number of loops and potential redundancy. 

Compiled with `--release` flag, this is now significantly faster than a Python implementation. On ~180,000 entries Python implementation takes about 16-18 seconds. Rust binary takes less than 2 seconds. 